### PR TITLE
Allow running composer with Drupal composer 8.9.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "drupal/core-dev": "*",
         "drush/drush": "^10.3.6",
         "phpspec/prophecy-phpunit": "^2.0",
-        "symfony/var-dumper": "^5.1"
+        "symfony/var-dumper": "^4.4 | ^5.1"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,


### PR DESCRIPTION
Fixes #2 

Test:
1. `cd repos/drupal`
1. `git checkout 8.9.x`
1. `cd ../..`
1. `composer update`

===

1. `cd repos/drupal`
1. `git checkout 9.2.x`
1. `cd ../..`
1. `composer update`