### PR TITLE
Adding gitmodules, to untrack repos/drupal changes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "drupal"]
+    path = repos/drupal
+    url = https://git.drupalcode.org/project/drupal.git
+    ignore = dirty


### PR DESCRIPTION
With `.gitmodules` file, we can run `git status` without notification about "changes" in the drupal repo `/repos/drupal`