### PR TITLE
Reduce composer install running time from over 6 minutes to 20 seconds

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "drupal/core": "*",
         "drupal/core-dev": "*",
         "drush/drush": "^10.3.6",
-        "phpspec/prophecy-phpunit": "^2.0",
+        "phpspec/prophecy-phpunit": "*",
         "symfony/var-dumper": "^4.4 | ^5.1"
     },
     "minimum-stability": "dev",


### PR DESCRIPTION
When running 
```
cd repos/drupal 
git checkout 8.9.x
```
Followed by -
```
time composer install -vvv
```

You'll see that it takes over 6 minutes to complete.

I was able to narrow down the issue to `prophecy-phpunit`.
When not specifying a version ( '*'), it will install version 1 of that package for Drupal 8.9.x, 9.0.x,
and version 2 for Drupal 9.1.x and Drupal 9.2.x


Please note, before this PR, while `composer install` takes a very long time to run, it DOES install `prophecy-phpunit` version 2 for any Drupal core version.
(I didn't know how to test if it breaks in any of the scenarios)