### PR TITLE
Add drush support for Drupal 10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "drupal/drupal": "*",
         "drupal/core": "*",
         "drupal/core-dev": "*",
-        "drush/drush": "^10.3.6",
+        "drush/drush": "^10.3.6 || ^11.x-dev",
         "phpspec/prophecy-phpunit": "*",
         "symfony/var-dumper": "^4.4 | ^5.1"
     },


### PR DESCRIPTION
Drupal 10 uses Twig 3, Drush needs to use v11 to be compatible.