### PR TITLE
Feature/alternative include

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,10 +30,10 @@
     ],
     "require": {
         "composer/installers": "^1.9",
-        "drupal/core-composer-scaffold": "*",
-        "drupal/drupal": "*",
         "drupal/core": "*",
+        "drupal/core-composer-scaffold": "*",
         "drupal/core-dev": "*",
+        "drupal/drupal": "*",
         "drush/drush": "^10.3.6 || ^11.x-dev",
         "phpspec/prophecy-phpunit": "*",
         "symfony/var-dumper": "^4.4 | ^5.1"
@@ -41,7 +41,13 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "composer/installers": true,
+            "drupal/core-vendor-hardening": true,
+            "drupal/core-project-message": true,
+            "drupal/core-composer-scaffold": true
+        }
     },
     "scripts": {
         "post-root-package-install": [
@@ -60,6 +66,10 @@
         "drupal-scaffold": {
             "locations": {
                 "web-root": "web/"
+            },
+            "file-mapping": {
+                "[web-root]/index.php": "scaffold/web/index.php",
+                "[web-root]/update.php": "scaffold/web/update.php"
             }
         },
         "installer-paths": {

--- a/composer.json
+++ b/composer.json
@@ -64,9 +64,6 @@
     },
     "extra": {
         "drupal-scaffold": {
-            "allowed-packages": [
-                "joachim-n/drupal-core-development-project"
-            ],
             "locations": {
                 "web-root": "web/"
             },

--- a/composer.json
+++ b/composer.json
@@ -64,6 +64,9 @@
     },
     "extra": {
         "drupal-scaffold": {
+            "allowed-packages": [
+                "joachim-n/drupal-core-development-project"
+            ],
             "locations": {
                 "web-root": "web/"
             },

--- a/scaffold/web/index.php
+++ b/scaffold/web/index.php
@@ -1,0 +1,3 @@
+<?php
+
+chdir(__DIR__ . '/../repos/drupal') && include __DIR__ . '/../repos/drupal/index.php';

--- a/scaffold/web/update.php
+++ b/scaffold/web/update.php
@@ -1,3 +1,3 @@
 <?php
 
-chdir(__DIR__ . '/../repos/drupal') && include __DIR__ . '/../repos/drupal/index.php';
+chdir(__DIR__ . '/../repos/drupal') && include __DIR__ . '/../repos/drupal/update.php';

--- a/scaffold/web/update.php
+++ b/scaffold/web/update.php
@@ -1,0 +1,3 @@
+<?php
+
+chdir(__DIR__ . '/../repos/drupal') && include __DIR__ . '/../repos/drupal/index.php';

--- a/src/ComposerScripts.php
+++ b/src/ComposerScripts.php
@@ -67,6 +67,7 @@ class ComposerScripts {
 
     // Symlink the simpletest folder into the Drupal core git repo.
     static::makeSymlink('../../../web/sites/simpletest', 'repos/drupal/sites/simpletest');
+    static::makeSymlink( 'repos/drupal/sites/default', '../../../web/sites/default');
   }
 
   /**

--- a/src/ComposerScripts.php
+++ b/src/ComposerScripts.php
@@ -50,8 +50,6 @@ class ComposerScripts {
     // See https://www.drupal.org/project/drupal/issues/3188703
     // See https://www.drupal.org/project/drupal/issues/1792310
     chdir('web');
-//    shell_exec('patch -p1 <../scaffold/scaffold-patch-index-php.patch');
-//    shell_exec('patch -p1 <../scaffold/scaffold-patch-update-php.patch');
 
     // Symlink the top-level vendor folder into the Drupal core git repo.
     chdir('..');
@@ -86,8 +84,6 @@ class ComposerScripts {
    *   The new link to create.
    */
   protected static function makeSymlink($target, $link) {
-    var_dump($target);
-    var_dump($link);
     if (file_exists($link)) {
       if (!is_link($link)) {
         print("WARNING: {$link} exists already and is not a symlink.\n");

--- a/src/ComposerScripts.php
+++ b/src/ComposerScripts.php
@@ -50,8 +50,8 @@ class ComposerScripts {
     // See https://www.drupal.org/project/drupal/issues/3188703
     // See https://www.drupal.org/project/drupal/issues/1792310
     chdir('web');
-    shell_exec('patch -p1 <../scaffold/scaffold-patch-index-php.patch');
-    shell_exec('patch -p1 <../scaffold/scaffold-patch-update-php.patch');
+//    shell_exec('patch -p1 <../scaffold/scaffold-patch-index-php.patch');
+//    shell_exec('patch -p1 <../scaffold/scaffold-patch-update-php.patch');
 
     // Symlink the top-level vendor folder into the Drupal core git repo.
     chdir('..');
@@ -65,9 +65,13 @@ class ComposerScripts {
       mkdir('web/sites/simpletest/browser_output', 0777, TRUE);
     }
 
+//    if (!file_exists('web/sites/default/files')) {
+//      mkdir('web/sites/default', 0777, TRUE);
+//    }
+
     // Symlink the simpletest folder into the Drupal core git repo.
     static::makeSymlink('../../../web/sites/simpletest', 'repos/drupal/sites/simpletest');
-    static::makeSymlink( 'repos/drupal/sites/default', '../../../web/sites/default');
+    static::makeSymlink( '../../../repos/drupal/sites/default/files', 'web/sites/default/files');
   }
 
   /**
@@ -82,6 +86,8 @@ class ComposerScripts {
    *   The new link to create.
    */
   protected static function makeSymlink($target, $link) {
+    var_dump($target);
+    var_dump($link);
     if (file_exists($link)) {
       if (!is_link($link)) {
         print("WARNING: {$link} exists already and is not a symlink.\n");


### PR DESCRIPTION
An experiement if it is possible without patches but with a little trick in the web directory we use on our projects.

This adds:
- index.php and update.php that includes core
- symlink for sites/default/files since there is css there

It seems to work pretty fine but because i use a custom packages.json it is not completely as it would be when in the main repository.

Tested usinig:
`drupal-core-development-packages.json`
```json
{
    "packages": {
        "joachim-n/drupal-core-development-project": {
            "dev-master": {
                "name": "joachim-n/drupal-core-development-project",
                "version": "2.0.0",
                "source": {
                    "url": "git@github.com:bbrala/drupal-core-development-project",
                    "type": "git",
                    "reference": "7ca81136b274d056e3f5fb21c16d7213f1520bd5"
                }
            }
        }
    }
}

```

Command:
`composer create-project --repository=./drupal-core-development-packages.json joachim-n/drupal-core-development-project coredev5 -vvv`
