### PR TITLE
add `php-http/discovery` to the list of allowed composer scripts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,6 +56,7 @@
             "drupal/core-project-message": true,
             "drupal/core-vendor-hardening": true,
             "drupal/core-composer-scaffold": true,
+            "php-http/discovery": true,
             "phpstan/extension-installer": true,
             "dealerdirect/phpcodesniffer-composer-installer": true
         }


### PR DESCRIPTION
This PR would let users skip this question on initial set up -
![image](https://github.com/joachim-n/drupal-core-development-project/assets/22901/7051e7f1-825f-4482-9b14-df7784569a50)
