### PR TITLE
Update the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ $ ddev config --project-type=drupal12 --docroot=web
 $ ddev start
 $ ddev composer create joachim-n/drupal-core-development-project
 ```
-In case you are on a case-insensite file system, like APFS on macOS, run: 
+In case you are on a case-insensitive file system, like APFS on macOS, run: 
 
 ```
 git -C ./repos/drupal config core.ignorecase true


### PR DESCRIPTION
the `drupal` project type isnt the recommended choice for a while now and the config update and the mandatory restart unnecessary. i've updated the install instructions recommending the latest version of DDEV (1.25.0). in consequence you are able to use the project type for drupal12. that is necessary because since a few weeks the main branch switched to version 12. so i set the config command to use the drupal12 project type and the docroot web. as already mentioned the config update and the restart became obsolete. and i then added a brief note about computers using a case insensitive file system and the command necessary to avoid trouble. 

p.s. and thank you for adding the latest list of plugins used by the drupal main branch as trusted plugins in version 2.0.0. that way the setup run through without a prompt! 