### PR TITLE
Small fix for composer create-project

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ for your project and `cd` into it. Then:
 ```
 $ ddev config --project-type=drupal12 --docroot=web
 $ ddev start
-$ ddev composer create joachim-n/drupal-core-development-project
+$ ddev composer create-project joachim-n/drupal-core-development-project
 ```
 In case you are on a case-insensitive file system, like APFS on macOS, run: 
 


### PR DESCRIPTION
One oversight in my last commit. I completely missed that `ddev composer create` was still being used. The current recommended standard is `ddev composer create-project`(see https://docs.ddev.com/en/stable/users/usage/commands/#composer)