### PR TITLE
remove the drush dependency, fixes #43

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ To install a Drupal project for working on Drupal core:
 
 ```
 $ composer create-project joachim-n/drupal-core-development-project
+$ composer require drush/drush:14.x-dev
 ```
 
 Composer will clone Drupal core into a 'repos/drupal' directory within the
@@ -40,7 +41,7 @@ start on a different branch without first checking out main, you can use the
 `--no-install` option with the `composer create-project` command, then change
 the branch of the Drupal core clone, then do `composer install`.
 
-Once the Composer installation is complete, you can install Drupal as normal,
+Once the Composer installation is complete, you can require Drush and install Drupal as normal,
 either with `drush si` or with the web UI.
 
 ### Installation on DDEV
@@ -52,6 +53,7 @@ for your project and `cd` into it. Then:
 $ ddev config --project-type=drupal12 --docroot=web
 $ ddev start
 $ ddev composer create-project joachim-n/drupal-core-development-project
+$ ddev composer require drush/drush:14.x-dev
 ```
 In case you are on a case-insensitive file system, like APFS on macOS, run:
 

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,6 @@
         "drupal/drupal": "*",
         "drupal/core-dev": "*",
         "drupal/core-recommended": "*",
-        "drush/drush": "^13",
         "phpspec/prophecy-phpunit": "*",
         "symfony/var-dumper": "*"
     },


### PR DESCRIPTION
removed the Drush dependency and updated the readme accordingly. the only references to Drush i've kept for now are the install paths in the composer.json's extra section and the `DevelopmentProjectCommands.php` file. Reason, I thought those will still be needed after Drush is manually required to alter the behavior of `drush cr`