### PR TITLE
Fix settings.php written to wrong directory when core/ is a symlink, fixes #38

### DIFF
--- a/scaffold/scaffold-patch-drupal-kernel-php.patch
+++ b/scaffold/scaffold-patch-drupal-kernel-php.patch
@@ -18,10 +18,10 @@ diff --git a/core/lib/Drupal/Core/DrupalKernel.php b/core/lib/Drupal/Core/Drupal
 +    // - Getting the path to the directory two levels up from the path
 +    //   determined in the previous step.
 +    $guessed = dirname(substr(__DIR__, 0, -strlen(__NAMESPACE__)), 2);
-+    // If autoload.php is absent from the guessed root, core/ is likely a
-+    // symlink and the real web root is elsewhere. Search ancestor directories
-+    // for a web root whose core/ symlink resolves to the same real path.
-+    if (!is_file($guessed . '/autoload.php') && is_dir($guessed . '/core')) {
++    // If core/ is a real directory (not a symlink), this path is the git
++    // clone root, not the web root. Search ancestor directories for a
++    // web root whose core/ symlink resolves to the same real path.
++    if (!is_link($guessed . '/core') && is_dir($guessed . '/core')) {
 +      $core_real_path = realpath($guessed . '/core');
 +      $search = dirname($guessed);
 +      while ($search !== dirname($search)) {
@@ -36,3 +36,4 @@ diff --git a/core/lib/Drupal/Core/DrupalKernel.php b/core/lib/Drupal/Core/Drupal
 +    }
 +    return $guessed;
    }
+

--- a/scaffold/scaffold-patch-drupal-kernel-php.patch
+++ b/scaffold/scaffold-patch-drupal-kernel-php.patch
@@ -1,23 +1,38 @@
 diff --git a/core/lib/Drupal/Core/DrupalKernel.php b/core/lib/Drupal/Core/DrupalKernel.php
 --- a/core/lib/Drupal/Core/DrupalKernel.php
 +++ b/core/lib/Drupal/Core/DrupalKernel.php
-@@ -345,7 +345,14 @@
+@@ -345,7 +345,29 @@
    protected static function guessApplicationRoot() {
 -    // Determine the application root by:
 -    // - Removing the namespace directories from the path.
 -    // - Getting the path to the directory two levels up from the path
 -    //   determined in the previous step.
 -    return dirname(substr(__DIR__, 0, -strlen(__NAMESPACE__)), 2);
-+    // In a web context, use DOCUMENT_ROOT to determine the application root
-+    // without resolving symlinks. This is needed when core/ is a symlinked
-+    // directory, as __DIR__ would otherwise resolve to the real filesystem
-+    // path rather than the logical web root.
-+    if (PHP_SAPI !== 'cli' && !empty($_SERVER['DOCUMENT_ROOT'])) {
-+      return rtrim($_SERVER['DOCUMENT_ROOT'], '/\\\\');
++    // Use DOCUMENT_ROOT when available (set by the web server to the configured
++    // docroot, without resolving symlinks when core/ is a symlinked directory).
++    if (!empty($_SERVER['DOCUMENT_ROOT'])) {
++      return rtrim($_SERVER['DOCUMENT_ROOT'], '/\\');
 +    }
 +    // Determine the application root by:
 +    // - Removing the namespace directories from the path.
 +    // - Getting the path to the directory two levels up from the path
 +    //   determined in the previous step.
-+    return dirname(substr(__DIR__, 0, -strlen(__NAMESPACE__)), 2);
++    $guessed = dirname(substr(__DIR__, 0, -strlen(__NAMESPACE__)), 2);
++    // If autoload.php is absent from the guessed root, core/ is likely a
++    // symlink and the real web root is elsewhere. Search ancestor directories
++    // for a web root whose core/ symlink resolves to the same real path.
++    if (!is_file($guessed . '/autoload.php') && is_dir($guessed . '/core')) {
++      $core_real_path = realpath($guessed . '/core');
++      $search = dirname($guessed);
++      while ($search !== dirname($search)) {
++        foreach (glob($search . '/*/autoload.php') ?: [] as $candidate) {
++          $candidate_root = dirname($candidate);
++          if (is_link($candidate_root . '/core') && realpath($candidate_root . '/core') === $core_real_path) {
++            return $candidate_root;
++          }
++        }
++        $search = dirname($search);
++      }
++    }
++    return $guessed;
    }

--- a/scaffold/scaffold-patch-drupal-kernel-php.patch
+++ b/scaffold/scaffold-patch-drupal-kernel-php.patch
@@ -1,0 +1,23 @@
+diff --git a/core/lib/Drupal/Core/DrupalKernel.php b/core/lib/Drupal/Core/DrupalKernel.php
+--- a/core/lib/Drupal/Core/DrupalKernel.php
++++ b/core/lib/Drupal/Core/DrupalKernel.php
+@@ -345,7 +345,14 @@
+   protected static function guessApplicationRoot() {
+-    // Determine the application root by:
+-    // - Removing the namespace directories from the path.
+-    // - Getting the path to the directory two levels up from the path
+-    //   determined in the previous step.
+-    return dirname(substr(__DIR__, 0, -strlen(__NAMESPACE__)), 2);
++    // In a web context, use DOCUMENT_ROOT to determine the application root
++    // without resolving symlinks. This is needed when core/ is a symlinked
++    // directory, as __DIR__ would otherwise resolve to the real filesystem
++    // path rather than the logical web root.
++    if (PHP_SAPI !== 'cli' && !empty($_SERVER['DOCUMENT_ROOT'])) {
++      return rtrim($_SERVER['DOCUMENT_ROOT'], '/\\\\');
++    }
++    // Determine the application root by:
++    // - Removing the namespace directories from the path.
++    // - Getting the path to the directory two levels up from the path
++    //   determined in the previous step.
++    return dirname(substr(__DIR__, 0, -strlen(__NAMESPACE__)), 2);
+   }

--- a/scaffold/scaffold-patch-install-core-inc.patch
+++ b/scaffold/scaffold-patch-install-core-inc.patch
@@ -1,0 +1,23 @@
+diff --git a/core/includes/install.core.inc b/core/includes/install.core.inc
+--- a/core/includes/install.core.inc
++++ b/core/includes/install.core.inc
+@@ -341,7 +341,10 @@ function install_begin_request($class_loader, &$install_state): void {
+   }
+ 
+   $site_path = empty($install_state['site_path']) ? DrupalKernel::findSitePath($request, FALSE) : $install_state['site_path'];
+-  Settings::initialize(dirname(__DIR__, 2), $site_path, $class_loader);
++  // Use DOCUMENT_ROOT to avoid resolving symlinks when core/ is a symlinked
++  // directory. dirname(__DIR__, 2) resolves via the real filesystem path.
++  $app_root = !empty($_SERVER['DOCUMENT_ROOT']) ? rtrim($_SERVER['DOCUMENT_ROOT'], '/\\') : dirname(__DIR__, 2);
++  Settings::initialize($app_root, $site_path, $class_loader);
+ 
+   // Ensure that procedural dependencies are loaded as early as possible,
+   // since the error/exception handlers depend on them.
+@@ -370,7 +373,7 @@ function install_begin_request($class_loader, &$install_state): void {
+   // Register the database driver extension list provider.
+   $container
+     ->register('extension.list.database_driver', 'Drupal\Core\Extension\DatabaseDriverList')
+-    ->addArgument(dirname(__DIR__, 2))
++    ->addArgument($app_root)
+     ->addArgument('database_driver')
+     ->addArgument(new NullBackend('database_driver'));

--- a/scaffold/scaffold-patch-install-core-inc.patch
+++ b/scaffold/scaffold-patch-install-core-inc.patch
@@ -1,19 +1,41 @@
 diff --git a/core/includes/install.core.inc b/core/includes/install.core.inc
 --- a/core/includes/install.core.inc
 +++ b/core/includes/install.core.inc
-@@ -341,7 +341,10 @@ function install_begin_request($class_loader, &$install_state): void {
+@@ -341,7 +341,32 @@ function install_begin_request($class_loader, &$install_state): void {
    }
  
    $site_path = empty($install_state['site_path']) ? DrupalKernel::findSitePath($request, FALSE) : $install_state['site_path'];
 -  Settings::initialize(dirname(__DIR__, 2), $site_path, $class_loader);
 +  // Use DOCUMENT_ROOT to avoid resolving symlinks when core/ is a symlinked
 +  // directory. dirname(__DIR__, 2) resolves via the real filesystem path.
-+  $app_root = !empty($_SERVER['DOCUMENT_ROOT']) ? rtrim($_SERVER['DOCUMENT_ROOT'], '/\\') : dirname(__DIR__, 2);
++  if (!empty($_SERVER['DOCUMENT_ROOT'])) {
++    $app_root = rtrim($_SERVER['DOCUMENT_ROOT'], '/\\');
++  }
++  else {
++    $app_root = dirname(__DIR__, 2);
++    // If core/ is a real directory (not a symlink), this path is the git
++    // clone root, not the web root. Search ancestor directories for a
++    // web root whose core/ symlink resolves to the same real path.
++    if (!is_link($app_root . '/core') && is_dir($app_root . '/core')) {
++      $core_real_path = realpath($app_root . '/core');
++      $search = dirname($app_root);
++      while ($search !== dirname($search)) {
++        foreach (glob($search . '/*/autoload.php') ?: [] as $candidate) {
++          $candidate_root = dirname($candidate);
++          if (is_link($candidate_root . '/core') && realpath($candidate_root . '/core') === $core_real_path) {
++            $app_root = $candidate_root;
++            break 2;
++          }
++        }
++        $search = dirname($search);
++      }
++    }
++  }
 +  Settings::initialize($app_root, $site_path, $class_loader);
  
    // Ensure that procedural dependencies are loaded as early as possible,
    // since the error/exception handlers depend on them.
-@@ -370,7 +373,7 @@ function install_begin_request($class_loader, &$install_state): void {
+@@ -370,7 +395,7 @@ function install_begin_request($class_loader, &$install_state): void {
    // Register the database driver extension list provider.
    $container
      ->register('extension.list.database_driver', 'Drupal\Core\Extension\DatabaseDriverList')

--- a/scaffold/scaffold-patch-install-php.patch
+++ b/scaffold/scaffold-patch-install-php.patch
@@ -1,0 +1,22 @@
+diff --git a/core/install.php b/core/install.php
+--- a/core/install.php
++++ b/core/install.php
+@@ -7,8 +7,14 @@
+
+ use Drupal\Component\Utility\OpCodeCache;
+
+-// Change the directory to the Drupal root.
+-chdir('..');
+-// Store the Drupal root path.
+-$root_path = realpath('');
++// Change the directory to the Drupal root.
++chdir('..');
++// Store the Drupal root path. Use SCRIPT_FILENAME when available to avoid
++// resolving symlinks incorrectly when core/ is a symlinked directory.
++if (PHP_SAPI !== 'cli' && isset($_SERVER['SCRIPT_FILENAME'])) {
++  $root_path = dirname($_SERVER['SCRIPT_FILENAME'], 2);
++}
++else {
++  $root_path = realpath('');
++}
+

--- a/scaffold/scaffold-patch-install-php.patch
+++ b/scaffold/scaffold-patch-install-php.patch
@@ -1,7 +1,7 @@
 diff --git a/core/install.php b/core/install.php
 --- a/core/install.php
 +++ b/core/install.php
-@@ -7,8 +7,14 @@
+@@ -7,8 +7,17 @@
 
  use Drupal\Component\Utility\OpCodeCache;
 
@@ -15,6 +15,9 @@ diff --git a/core/install.php b/core/install.php
 +// resolving symlinks incorrectly when core/ is a symlinked directory.
 +if (PHP_SAPI !== 'cli' && isset($_SERVER['SCRIPT_FILENAME'])) {
 +  $root_path = dirname($_SERVER['SCRIPT_FILENAME'], 2);
++  // Correct CWD so that relative paths in the install process (e.g.
++  // './' . $site_path in install.core.inc) resolve to the web root.
++  chdir($root_path);
 +}
 +else {
 +  $root_path = realpath('');

--- a/src/ComposerScripts.php
+++ b/src/ComposerScripts.php
@@ -62,6 +62,7 @@ class ComposerScripts {
     // through web/core because GNU patch 2.7+ refuses to traverse symlinks.
     chdir('../repos/drupal');
     shell_exec('patch --follow-symlinks -p1 <../../scaffold/scaffold-patch-install-php.patch');
+    shell_exec('patch --follow-symlinks -p1 <../../scaffold/scaffold-patch-install-core-inc.patch');
     shell_exec('patch --follow-symlinks -p1 <../../scaffold/scaffold-patch-drupal-kernel-php.patch');
 
     // Symlink the top-level vendor folder into the Drupal core git repo.

--- a/src/ComposerScripts.php
+++ b/src/ComposerScripts.php
@@ -50,12 +50,16 @@ class ComposerScripts {
     // See https://github.com/composer/composer/issues/7911
     include './vendor/symfony/var-dumper/Resources/functions/dump.php';
 
-    // Apply a patch to the scaffold index.php file.
+    // Apply patches to scaffold files and the Drupal core git clone.
     // See https://www.drupal.org/project/drupal/issues/3188703
     // See https://www.drupal.org/project/drupal/issues/1792310
     chdir('web');
     shell_exec('patch -p1 <../scaffold/scaffold-patch-index-php.patch');
     shell_exec('patch -p1 <../scaffold/scaffold-patch-update-php.patch');
+    // Patch core/install.php and DrupalKernel to fix symlinked core/ root path
+    // detection.
+    shell_exec('patch -p1 <../scaffold/scaffold-patch-install-php.patch');
+    shell_exec('patch -p1 <../scaffold/scaffold-patch-drupal-kernel-php.patch');
 
     // Symlink the top-level vendor folder into the Drupal core git repo.
     chdir('..');

--- a/src/ComposerScripts.php
+++ b/src/ComposerScripts.php
@@ -56,13 +56,16 @@ class ComposerScripts {
     chdir('web');
     shell_exec('patch -p1 <../scaffold/scaffold-patch-index-php.patch');
     shell_exec('patch -p1 <../scaffold/scaffold-patch-update-php.patch');
+
     // Patch core/install.php and DrupalKernel to fix symlinked core/ root path
-    // detection.
-    shell_exec('patch -p1 <../scaffold/scaffold-patch-install-php.patch');
-    shell_exec('patch -p1 <../scaffold/scaffold-patch-drupal-kernel-php.patch');
+    // detection. These patches must be applied from repos/drupal/ rather than
+    // through web/core because GNU patch 2.7+ refuses to traverse symlinks.
+    chdir('../repos/drupal');
+    shell_exec('patch --follow-symlinks -p1 <../../scaffold/scaffold-patch-install-php.patch');
+    shell_exec('patch --follow-symlinks -p1 <../../scaffold/scaffold-patch-drupal-kernel-php.patch');
 
     // Symlink the top-level vendor folder into the Drupal core git repo.
-    chdir('..');
+    chdir('../..');
     static::makeSymlink('../../vendor', 'repos/drupal/vendor');
 
     // Create folders for running tests.


### PR DESCRIPTION
## Problem

This project places the Drupal git clone at `repos/drupal/` and symlinks `web/core -> ../repos/drupal/core/`. PHP resolves symlinks when computing `__DIR__`, `realpath()`, and `chdir('..')`, so several places in Drupal's installer compute `repos/drupal/` as the application root instead of `web/`. The result: `settings.php` is written to `repos/drupal/sites/default/` instead of `web/sites/default/`, DDEV's `settings.ddev.php` is never loaded, the web installer prompts for database credentials it should already know, and drush appends database credentials to `settings.php` unnecessarily.

## Root causes and fixes

Three files in Drupal core needed patching, each applied from `repos/drupal/` (not through `web/core`) because GNU patch 2.7+ refuses to traverse symlinks.

The key discriminator throughout is `is_link($path . '/core')`: in `repos/drupal/`, `core/` is a real directory; in `web/`, `core/` is a symlink. When `core/` is a real directory, we search ancestor directories for a sibling whose `core/` symlink resolves to the same real path.

**`core/install.php`**
`chdir('..')` from inside the symlinked `core/` directory sets CWD to `repos/drupal/`. All relative paths (including `'./' . $site_path . '/settings.php'` in `install.core.inc`) then resolve under `repos/drupal/`. Fix: use `$_SERVER['SCRIPT_FILENAME']` (set by nginx to the unresolved docroot path) to compute `$root_path`, then call `chdir($root_path)` to correct CWD.

**`core/includes/install.core.inc`**
`install_begin_request()` calls `Settings::initialize(dirname(__DIR__, 2), ...)`. `__DIR__` resolves via the real filesystem path to `repos/drupal/core/includes`, so `Settings::initialize()` looks for `settings.php` in `repos/drupal/sites/default/` and finds nothing — causing the web installer to prompt for database config and drush to write credentials into `settings.php`. In web context, use `$_SERVER['DOCUMENT_ROOT']`. In CLI context (drush), detect that `core/` is a real directory and search ancestor directories for the web root.

**`core/lib/Drupal/Core/DrupalKernel.php`**
`guessApplicationRoot()` uses `__DIR__` for the same reason. Same fix: `DOCUMENT_ROOT` for web context, ancestor directory search for CLI.

## Testing with DDEV

Requirements: [DDEV](https://ddev.com) installed.

```bash
mkdir ~/tmp/drupal-test && cd ~/tmp/drupal-test
ddev config --project-type=drupal12 --docroot=web
ddev start
ddev composer create-project \
  --repository='{"url":"git@github.com:rfay/drupal-core-development-project","type":"vcs"}' \
  --stability=dev \
  "joachim-n/drupal-core-development-project:dev-20260429_rfay_use_correct_docroot"
```

**Test 1 — drush install:**
```bash
ddev composer require drush/drush
ddev drush site:install standard --yes --account-name=admin --account-pass=admin
```

Expected:
- Install completes successfully
- `settings.php` exists only at `web/sites/default/settings.php`
- Nothing at `repos/drupal/sites/default/settings.php`
- No database credentials appended to the end of `web/sites/default/settings.php`

**Test 2 — web installer:**

Drop the database and remove `settings.php` to start fresh:
```bash
ddev drush sql-drop -y
rm web/sites/default/settings.php
ddev restart   # DDEV recreates settings.php and settings.ddev.php
ddev exec "chmod 777 /var/www/html/web/sites/default && chmod 666 /var/www/html/web/sites/default/settings.php"
```

Visit `https://drupal-test.ddev.site/core/install.php` in a browser.

Expected: the installer proceeds language → profile → "Installing Drupal" **without prompting for database credentials** (DDEV's `settings.ddev.php` is loaded automatically). After installation completes, `settings.php` should exist only at `web/sites/default/settings.php`.

**Verify the wrong location is empty:**
```bash
ls repos/drupal/sites/default/
# Should show only: default.services.yml  default.settings.php
# settings.php must NOT be present
```
